### PR TITLE
Add admin dashboard with management features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # E-Commerce Flask App
 
-This is a simple e-commerce web application using Flask. It supports user registration, login, product listing, shopping carts and order history.
+This is a simple e-commerce web application using Flask. It supports user registration, login, product listing, shopping carts and order history. An admin interface allows management of users, products and orders.
 
 ## Features
 
@@ -39,3 +39,7 @@ python app.py
 ```
 
 Visit `http://127.0.0.1:5000` in your browser.
+
+## Admin Login
+
+An initial admin user is created automatically with username `admin` and password `admin`. Use this account to access the `/admin` area for managing data.

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Admin Dashboard</h2>
+<ul>
+  <li>Total users: {{ user_count }}</li>
+  <li>Total products: {{ product_count }}</li>
+  <li>Total orders: {{ order_count }}</li>
+  <li>Total revenue: ${{ '%.2f'|format(revenue) }}</li>
+</ul>
+<nav>
+  <a href="{{ url_for('manage_users') }}">Manage Users</a> |
+  <a href="{{ url_for('manage_products') }}">Manage Products</a> |
+  <a href="{{ url_for('manage_orders') }}">View Orders</a>
+</nav>
+{% endblock %}

--- a/templates/admin/orders.html
+++ b/templates/admin/orders.html
@@ -1,0 +1,26 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Orders</h2>
+<table>
+  <thead>
+    <tr><th>Date</th><th>User</th><th>Items</th><th>Total</th></tr>
+  </thead>
+  <tbody>
+  {% for order in orders %}
+    <tr>
+      <td>{{ order.created_at.strftime('%Y-%m-%d') }}</td>
+      <td>{{ order.user_id }}</td>
+      <td>{{ order.items|length }}</td>
+      <td>
+        ${%- set tot = 0 -%}
+        {%- for item in order.items -%}
+            {%- set tot = tot + item.price * item.quantity -%}
+        {%- endfor -%}
+        {{ '%.2f'|format(tot) }}
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+<p><a href="{{ url_for('admin_dashboard') }}">Back</a></p>
+{% endblock %}

--- a/templates/admin/products.html
+++ b/templates/admin/products.html
@@ -1,0 +1,36 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Manage Products</h2>
+<form method="post">
+  <label>Name <input type="text" name="name" required></label>
+  <label>Price <input type="number" step="0.01" name="price" required></label>
+  <label>Category
+    <select name="category">
+      {% for cat in categories %}
+        <option value="{{ cat.id }}">{{ cat.name }}</option>
+      {% endfor %}
+    </select>
+  </label>
+  <button type="submit">Add</button>
+</form>
+<table>
+  <thead>
+    <tr><th>Name</th><th>Price</th><th>Category</th><th></th></tr>
+  </thead>
+  <tbody>
+  {% for p in products %}
+    <tr>
+      <td>{{ p.name }}</td>
+      <td>${{ '%.2f'|format(p.price) }}</td>
+      <td>{{ p.category.name if p.category else '' }}</td>
+      <td>
+        <form method="post" style="display:inline">
+          <button name="delete" value="{{ p.id }}" onclick="return confirm('Delete product?')">Delete</button>
+        </form>
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+<p><a href="{{ url_for('admin_dashboard') }}">Back</a></p>
+{% endblock %}

--- a/templates/admin/users.html
+++ b/templates/admin/users.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Manage Users</h2>
+<table>
+  <thead>
+    <tr><th>Username</th><th>Admin</th><th></th></tr>
+  </thead>
+  <tbody>
+  {% for u in users %}
+    <tr>
+      <td>{{ u.username }}</td>
+      <td>{{ 'Yes' if u.is_admin else 'No' }}</td>
+      <td>
+        {% if u.id != current_user.id %}
+        <form method="post" style="display:inline">
+          <button name="delete" value="{{ u.id }}" onclick="return confirm('Delete user?')">Delete</button>
+        </form>
+        {% endif %}
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+<p><a href="{{ url_for('admin_dashboard') }}">Back</a></p>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,6 +11,9 @@
     <a href="{{ url_for('cart_view') }}">Cart</a>
     {% if current_user.is_authenticated %}
         <span>Logged in as {{ current_user.username }}</span>
+        {% if current_user.is_admin %}
+            <a href="{{ url_for('admin_dashboard') }}">Admin</a>
+        {% endif %}
         <a href="{{ url_for('profile') }}">Profile</a>
         <a href="{{ url_for('logout') }}">Logout</a>
     {% else %}


### PR DESCRIPTION
## Summary
- enable admin flag on `User` model and seed default admin account
- protect new routes with `admin_required`
- add admin dashboard, user/product/order management and reporting
- show Admin link in header for admins
- document admin login in README

## Testing
- `python -m py_compile app.py`
- `flask --app app routes`

------
https://chatgpt.com/codex/tasks/task_e_68691a81643083318dfc32ca0f2be6cc